### PR TITLE
Fix retrieving the uncompressed length of a stream.

### DIFF
--- a/decompress.cc
+++ b/decompress.cc
@@ -349,7 +349,7 @@ bool Gipfeli::GetUncompressedLengthStream(
   *result = 0;
   for (int i = bytes_used - 1; i >= 0; --i) {
     *result <<= 8;
-    *result |= *(ip + i);
+    *result |= *(ip + i) & 0xff;
   }
 
   // Uncompressed string can have at most (2 GB - 1).


### PR DESCRIPTION
Without this UncompressStream will often fail because the it thinks the length is >= 1 << 31.

Blocks https://github.com/quixdb/squash/issues/22
