### PR TITLE
Clean up some warnings in header files.

### DIFF
--- a/sinksource.h
+++ b/sinksource.h
@@ -43,9 +43,9 @@ class MemBlock {
 
  protected:
   // For use by subclasses
-  MemBlock(void* data, size_t length) {
-    data_ = orig_data_ = data;
-    length_ = orig_length_ = length;
+  MemBlock(void* mem, size_t len) {
+    data_ = orig_data_ = mem;
+    length_ = orig_length_ = len;
   }
 
  private:
@@ -61,8 +61,8 @@ class MemBlock {
 // char[]', and it will be delete[]'ed when this object is destroyed.
 class NewedMemBlock: public MemBlock {
  public:
-  NewedMemBlock(char* space, size_t length)
-      : MemBlock(space, length) {
+  NewedMemBlock(char* space, size_t len)
+      : MemBlock(space, len) {
       assert(orig_data() != NULL);
   }
   virtual ~NewedMemBlock() {

--- a/stubs-internal.h
+++ b/stubs-internal.h
@@ -43,7 +43,7 @@
 // When building with C++11 toolchains, just use the language support
 // for explicitly deleted methods. This doesn't delete the move constructor,
 // so objects can still be stored in move-aware containers, like std::vector.
-#if LANG_CXX11
+#ifdef LANG_CXX11
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&) = delete;      \
   void operator=(const TypeName&) = delete


### PR DESCRIPTION
These warnings are triggered when compiling with -Wshadow or -Wundef.
Since they are in header files they will also be triggered in any
project attempting to use gipfeli while compiling with those warnings
enabled.

For an example of this triggering warnings in an external project, see https://travis-ci.org/quixdb/squash/jobs/56952895#L1141