### PR TITLE
Fix memory leak when sinks throw an exception

### DIFF
--- a/gipfeli-internal.cc
+++ b/gipfeli-internal.cc
@@ -268,7 +268,13 @@ size_t Gipfeli::CompressStream(
     }
 
     if (scratch_output == dest) {
-      writer->AppendMemBlock(new NewedMemBlock(scratch_output, output_size));
+      NewedMemBlock* new_block = new NewedMemBlock(scratch_output, output_size);
+      try {
+        writer->AppendMemBlock(new_block);
+      } catch (...) {
+        delete new_block;
+        throw;
+      }
       scratch_output = NULL;
       scratch_output_size = 0;
     } else {

--- a/stubs-internal.h
+++ b/stubs-internal.h
@@ -8,8 +8,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <sys/uio.h>
-#include <sys/mman.h>
 #include <string>
 
 #include "config.h"


### PR DESCRIPTION
This allows custom sink implementations which can throw an exception
(for example, when there is insufficient space to store the output)
to be used, while avoiding memory leaks which could occur in the event
such an exception is thrown.