### PR TITLE
Fix use of pointer into string after assignment

### DIFF
--- a/gipfeli-internal.cc
+++ b/gipfeli-internal.cc
@@ -277,7 +277,7 @@ size_t Gipfeli::CompressStream(
     }
 
     bytes_written += output_size;
-    prev_block = input_block;
+    std::swap(prev_block, input_block);
     input_block = block_reader.GetNextBlock();
   }
 

--- a/gipfeli-internal.cc
+++ b/gipfeli-internal.cc
@@ -236,9 +236,10 @@ size_t Gipfeli::CompressStream(
   uint32 content_size = 0;
   uint32 commands_size = 0;
 
-  const char* prev_block = NULL;
+  string prev_block;
   while (input_block.size()) {
-    lz77->CompressFragment(input_block.data(), input_block.size(), prev_block,
+    lz77->CompressFragment(input_block.data(), input_block.size(),
+                           prev_block.empty() ? NULL : prev_block.data(),
                            &content, &content_size, &commands, &commands_size);
 
     // We add 64 bytes for potential entropy overhead.
@@ -276,7 +277,7 @@ size_t Gipfeli::CompressStream(
     }
 
     bytes_written += output_size;
-    prev_block = input_block.data();
+    prev_block = input_block;
     input_block = block_reader.GetNextBlock();
   }
 


### PR DESCRIPTION
I am trying to get squash to work with MSVC (quixdb/squash#145), and gipfeli was one of the plugins that crashed. After failing to debug it in Windows, I ran it through Valgrind, and found this.

It looks like `prev_block` is set to point into the data of the string `input_block`, which is then assigned a different value, which should invalidate all pointers.