### PR TITLE
Fix read of uninitialized memory

### DIFF
--- a/find_match_length.h
+++ b/find_match_length.h
@@ -63,7 +63,7 @@ static inline int MultiBlockFindMatchLength(const uint8* s1,
       s1_limit = s2_limit;
     }
   }
-  while (PREDICT_TRUE((s2 < s2_limit) && (*s1 == *s2))) {
+  while (PREDICT_TRUE((s2 < s2_limit) && (s1 < s1_limit) && (*s1 == *s2))) {
     s1++;
     s2++;
   }
@@ -83,7 +83,7 @@ static inline int MultiBlockFindMatchLength(const uint8* s1,
   // time until we find a 32-bit block that doesn't match; then we find
   // the first non-matching bit and use that to calculate the total
   // length of the match.
-  while (s2 <= s2_limit - 4 &&
+  while (s2 <= s2_limit - 4 && s1 <= s1_limit - 4 &&
          UNALIGNED_LOAD32(s2) == UNALIGNED_LOAD32(s1)) {
     if (PREDICT_FALSE(s1 >= s1_limit)) {
       s1 = s2_base + (s1 - s1_limit);
@@ -93,7 +93,7 @@ static inline int MultiBlockFindMatchLength(const uint8* s1,
     s1 += 4;
   }
 
-  while ((s2 < s2_limit) && (*s1 == *s2)) {
+  while ((s2 < s2_limit) && (s1 < s1_limit) && (*s1 == *s2)) {
     s1++;
     s2++;
   }

--- a/find_match_length.h
+++ b/find_match_length.h
@@ -40,7 +40,7 @@ static inline int MultiBlockFindMatchLength(const uint8* s1,
   // time until we find a 64-bit block that doesn't match; then we find
   // the first non-matching bit and use that to calculate the total
   // length of the match.
-  while (PREDICT_TRUE(s2 <= s2_limit - 8)) {
+  while (PREDICT_TRUE(s2 <= s2_limit - 8 && s1 <= s1_limit - 8)) {
     if (PREDICT_FALSE(UNALIGNED_LOAD64(s2) == UNALIGNED_LOAD64(s1))) {
       s2 += 8;
       s1 += 8;


### PR DESCRIPTION
Similar to #4, Valgrind reports use of uninitialized memory in the comparison in line 44. Checking if there is enough space at `s1` appears to help.