### PR TITLE
Don't hardcode HAVE_BUILTIN_* macros in config.h

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,9 +1,21 @@
 /* Some basic macro definitions for high performance.
- * If something is not supported by your system, turn it off.
- * This will be substituted by automatic script in future.*/
+ * You can use a build system (such as autotools or cmake) to test for
+ * these features and define HAVE_* or NO_* to turn them on or off.
+ * Otherwise, attempt to determine support based on checking macros
+ * defined by the compiler and/or libc. */
 
-/* Define to 1 if the compiler supports __builtin_ctz and friends. */
-#define HAVE_BUILTIN_CTZ 1
+/* Define to 1 if the compiler supports __builtin_ctz and friends.
+   Clang and Intel both define __GNUC__ (and support __builtin_ctz and
+   __builtin_expect) */
+#if !defined(NO_BUILTIN_CTZ) && !defined(HAVE_BUILTIN_CTZ)
+#  if defined(__GNUC__)
+#    define HAVE_BUILTIN_CTZ 1
+#  endif
+#endif
 
 /* Define to 1 if the compiler supports __builtin_expect. */
-#define HAVE_BUILTIN_EXPECT 1
+#if !defined(NO_BUILTIN_EXPECT) && !defined(HAVE_BUILTIN_EXPECT)
+#  if defined(__GNUC__)
+#    define HAVE_BUILTIN_EXPECT 1
+#  endif
+#endif


### PR DESCRIPTION
This makes it possible to use a build system to detect support for
the builtins, but also uses predefined macros as a fallback instead
of just hardcoding the assumption that they exist.
