### PR TITLE
Fix undefined behavior.

### DIFF
--- a/entropy.cc
+++ b/entropy.cc
@@ -195,7 +195,7 @@ void Entropy::FlushBits(uint32 bits, uint64* bit_buffer_64) {
   // Output the rest of bit_buffer
   if (bits != 0) {
     *bit_buffer_64 <<= 64 - bits;
-    *write_bits_pos_++ = *bit_buffer_64;
+    UNALIGNED_STORE64(write_bits_pos_++, *bit_buffer_64);
   }
 }
 

--- a/entropy.h
+++ b/entropy.h
@@ -143,7 +143,7 @@ void Entropy::WriteBits(int length,
     *bit_buffer_64 <<= 64 - *bits;
     *bits -= v;
     *bit_buffer_64 |= value >> *bits;
-    *write_bits_pos_++ = *bit_buffer_64;
+    UNALIGNED_STORE64(write_bits_pos_++, *bit_buffer_64);
     // We can write the whole value in the bit_buffer_64.
     // Consequent WriteBits or FlushBits calls will erase
     // the extra high bits.

--- a/read_bits.h
+++ b/read_bits.h
@@ -37,7 +37,7 @@ class ReadBits {
       current_ <<= length;
       bits_left_ -= length;
     } else {
-      ret = (current_ >> (64 - bits_left_)) << (length - bits_left_);
+      ret = bits_left_ > 0 ? (current_ >> (64 - bits_left_)) << (length - bits_left_) : 0;
       length -= bits_left_;
       if (PREDICT_FALSE((bits_input_ + sizeof(uint64)) > input_end_)) {
         error_ = true;

--- a/stubs-internal.h
+++ b/stubs-internal.h
@@ -70,7 +70,7 @@ static const int64 kint64max = static_cast<int64>(0x7FFFFFFFFFFFFFFFLL);
 
 // x86 and PowerPC can simply do these loads and stores native.
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__)
+#if !defined(GIPFELI_NO_UNALIGNED) && (defined(__i386__) || defined(__x86_64__) || defined(__powerpc__))
 
 #define UNALIGNED_LOAD16(_p) (*reinterpret_cast<const uint16 *>(_p))
 #define UNALIGNED_LOAD32(_p) (*reinterpret_cast<const uint32 *>(_p))
@@ -89,19 +89,20 @@ static const int64 kint64max = static_cast<int64>(0x7FFFFFFFFFFFFFFFLL);
 //
 // This is a mess, but there's not much we can do about it.
 
-#elif defined(__arm__) && \
-      !defined(__ARM_ARCH_4__) && \
-      !defined(__ARM_ARCH_4T__) && \
-      !defined(__ARM_ARCH_5__) && \
-      !defined(__ARM_ARCH_5T__) && \
-      !defined(__ARM_ARCH_5TE__) && \
-      !defined(__ARM_ARCH_5TEJ__) && \
-      !defined(__ARM_ARCH_6__) && \
-      !defined(__ARM_ARCH_6J__) && \
-      !defined(__ARM_ARCH_6K__) && \
-      !defined(__ARM_ARCH_6Z__) && \
-      !defined(__ARM_ARCH_6ZK__) && \
-      !defined(__ARM_ARCH_6T2__)
+#elif !defined(GIPFELI_NO_UNALIGNED) && \
+      (defined(__arm__) && \
+       !defined(__ARM_ARCH_4__) && \
+       !defined(__ARM_ARCH_4T__) && \
+       !defined(__ARM_ARCH_5__) && \
+       !defined(__ARM_ARCH_5T__) && \
+       !defined(__ARM_ARCH_5TE__) && \
+       !defined(__ARM_ARCH_5TEJ__) && \
+       !defined(__ARM_ARCH_6__) && \
+       !defined(__ARM_ARCH_6J__) && \
+       !defined(__ARM_ARCH_6K__) && \
+       !defined(__ARM_ARCH_6Z__) && \
+       !defined(__ARM_ARCH_6ZK__) && \
+       !defined(__ARM_ARCH_6T2__))
 
 #define UNALIGNED_LOAD16(_p) (*reinterpret_cast<const uint16 *>(_p))
 #define UNALIGNED_LOAD32(_p) (*reinterpret_cast<const uint32 *>(_p))


### PR DESCRIPTION
This will avoid unaligned access if GIPFELI_NO_UNALIGNED is defined,
even on platforms where unaligned access is assumed to be acceptable.
It also fixes a few locations which previously assumed unaligned
access instead of using the UNALIGNED_STORE64 macro, and avoids
right-shifting a 64-bit value by 64 bits, which is undefined behavior.