### PR TITLE
Use the optimized code path for FindMatchLength on PowerPC

### DIFF
--- a/stubs-internal.h
+++ b/stubs-internal.h
@@ -289,7 +289,8 @@ inline char* string_as_array(std::string* str) {
 //   and n <= (s2_limit - s2).
 //
 // Separate implementation for x86_64, for speed.
-#if defined(__GNUC__) && defined(ARCH_K8)
+#if (defined(__GNUC__) && (defined(ARCH_K8) \
+                           || (defined(__ppc64__) && defined(_LITTLE_ENDIAN))))
 static inline int FindMatchLength(const uint8* s1,
                                   const uint8* s2,
                                   const uint8* s2_limit) {

--- a/stubs-internal.h
+++ b/stubs-internal.h
@@ -288,7 +288,7 @@ inline char* string_as_array(std::string* str) {
 //   s1[0,n-1] == s2[0,n-1]
 //   and n <= (s2_limit - s2).
 //
-// Separate implementation for x86_64, for speed.
+// Separate implementation for x86_64 and little endian PPC, for speed.
 #if (defined(__GNUC__) && (defined(ARCH_K8) \
                            || (defined(__ppc64__) && defined(_LITTLE_ENDIAN))))
 static inline int FindMatchLength(const uint8* s1,


### PR DESCRIPTION
Using this code path for PowerPC Little Endian improves performance
by a few percent (most notably for compression). There will be further
performance improvements with PowerPC implementations of ISA 3.0 as
the ISA will support the count trailing zeros instruction.