### PR TITLE
Include algorithm when using std::min and max

### DIFF
--- a/entropy.cc
+++ b/entropy.cc
@@ -2,6 +2,7 @@
 
 #include "entropy.h"
 
+#include <algorithm>
 #include <string.h>
 #include <string>
 

--- a/sinksource.h
+++ b/sinksource.h
@@ -3,6 +3,7 @@
 
 // Based on Snappy sink source implementation.
 
+#include <algorithm>
 #include <stddef.h>
 #include "stubs-internal.h"
 


### PR DESCRIPTION
Clang/C2 is complaining about the use of `std::min` and `std::max` without including `<algorithm>`.